### PR TITLE
Update postIndependentNVLBlock function to include

### DIFF
--- a/main.go
+++ b/main.go
@@ -376,11 +376,13 @@ func postIndependentNVLBlock(block *NVLBlock) error {
 	log.Println("Posting new block to NVL Proxy")
 
 	body := struct {
-		Version string    `json:"version"`
-		Block   *NVLBlock `json:"block"`
+		Version                  string    `json:"version"`
+		Block                    *NVLBlock `json:"block"`
+		IndependentSignerVersion string    `json:"independentSignerVersion"`
 	}{
-		Version: "1",
-		Block:   block,
+		Version:                  "1",
+		Block:                    block,
+		IndependentSignerVersion: Version,
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	Version = "v0.0.0"
+	Version = "v0.0.1"
 
 	dataDir string
 


### PR DESCRIPTION
These changes will consider the `main.Version` as the Independent Signer Version to be sent to the NVL Server

**_When the Burn Coiin feature is ready, the `main.Version` should be updated._**